### PR TITLE
Added guard protections for requests / responses

### DIFF
--- a/getter.go
+++ b/getter.go
@@ -77,6 +77,13 @@ func newGetter(getURL url.URL, c *Config, b *Bucket) (io.ReadCloser, http.Header
 	if resp.StatusCode != 200 {
 		return nil, nil, newRespError(resp)
 	}
+
+	// Golang changes content-length to -1 when chunked transfer encoding / EOF close response detected
+	if resp.ContentLength == -1 {
+		return nil, nil, fmt.Errorf("Retrieving objects with undefined content-length " +
+			" responses (chunked transfer encoding / EOF close) is not supported")
+	}
+
 	g.contentLen = resp.ContentLength
 	g.chunkTotal = int((g.contentLen + g.bufsz - 1) / g.bufsz) // round up, integer division
 	logger.debugPrintf("object size: %3.2g MB", float64(g.contentLen)/float64((1*mb)))

--- a/s3gof3r.go
+++ b/s3gof3r.go
@@ -3,6 +3,7 @@
 package s3gof3r
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -84,6 +85,9 @@ func (s3 *S3) Bucket(name string) *Bucket {
 // Header data from the downloaded object is also returned, useful for reading object metadata.
 // DefaultConfig is used if c is nil
 func (b *Bucket) GetReader(path string, c *Config) (r io.ReadCloser, h http.Header, err error) {
+	if path == "" {
+		return nil, nil, errors.New("Empty path requested")
+	}
 	if c == nil {
 		c = b.conf()
 	}


### PR DESCRIPTION
Add guard to handle if nil path is requested
Add guard to handle if content-length from response is -1 which represents that the response is chunked transfer encoding or EOF close response
