### PR TITLE
Add WriterTo interface, combine structs

### DIFF
--- a/getter.go
+++ b/getter.go
@@ -19,21 +19,24 @@ const (
 )
 
 type getter struct {
+	url   url.URL
 	b     *Bucket
 	bufsz int64
 	err   error
 	wg    sync.WaitGroup
 
 	chunkID    int
-	rChunk     *Chunk
+	rChunk     *chunk
+	contentLen int64
 	bytesRead  int64
 	chunkTotal int
 	chunkCounter int
 	chunkWg sync.WaitGroup
 
-	readCh chan *Chunk
-	getCh  chan *Chunk
+	readCh chan *chunk
+	getCh  chan *chunk
 	quit   chan struct{}
+	qWait  map[int]*chunk
 
 	sp *bp
 
@@ -42,50 +45,37 @@ type getter struct {
 
 	md5  hash.Hash
 	cIdx int64
-	contentLen int64
-	qWait      map[int]*Chunk
-	url        url.URL
-}
-
-type singleGetter struct {
-	getter
 
 }
 
-//New struct to hold methods that only make sense for multi-file downloads
-type batchGetter struct {
-	getter
-}
-
-type Chunk struct {
-	Id         int // The chunk number for the file being retrieved
-	Start      int64 // The position in the requested file at which this chunk's data begins
-	ChunkSize  int64 // Number of bytes contained in this chunk
-	FileSize   int64 // Total size of the requested file
-	Bytes      []byte // The bytes retrieved from S3. Length is set by cfg.PartSize, but only contains ChunkSize bytes
-	Path       string // S3 file path this chunk comes from
-	Error      error // contains the error that occurred, if any, while retrieving this chunk
+type chunk struct {
+	id int // The chunk number for the file being retrieved
+	start int64 // The position in the requested file at which this chunk's data begins
+	size int64 // Number of bytes contained in this chunk
+	fileSize int64 // Total size of the requested file
+	b []byte // The bytes retrieved from S3. Length is set by cfg.PartSize, but only contains ChunkSize bytes
+	path string // S3 file path this chunk comes from
+	error error // contains the error that occurred, if any, while retrieving this chunk
 	header     http.Header
-	chunkTotal int64
 	response   *http.Response
 	url        url.URL
 }
 
-func newBatchGetter(c *Config, b *Bucket) *batchGetter {
-	g := new(batchGetter)
+func newBatchGetter( c *Config, b *Bucket) (*getter, error) {
+	g := new(getter)
 	g.c = c
 	g.bufsz = max64(c.PartSize, 1)
 	g.c.NTry = max(c.NTry, 1)
 	g.c.Concurrency = max(c.Concurrency, 1)
 
-	g.getCh = make(chan *Chunk, 2*c.Concurrency)
-	g.readCh = make(chan *Chunk, 2*c.Concurrency)
+	g.getCh = make(chan *chunk, c.Concurrency)
+	g.readCh = make(chan *chunk, c.Concurrency)
 	g.quit = make(chan struct{})
+	g.qWait = make(map[int]*chunk)
 	g.b = b
 	g.md5 = md5.New()
 	g.chunkTotal = 0
 	g.chunkCounter = 0
-	g.qWait = make(map[int]*Chunk)
 
 
 	g.sp = bufferPool(g.bufsz)
@@ -93,50 +83,27 @@ func newBatchGetter(c *Config, b *Bucket) *batchGetter {
 	for i := 0; i < g.c.Concurrency; i++ {
 		go g.worker()
 	}
-	return g
+
+	return g, nil
 }
 
 func newGetter(getURL url.URL, c *Config, b *Bucket) (io.ReadCloser, http.Header, error) {
-	g := new(singleGetter)
-	g.url = getURL
-	g.c = c
-	g.bufsz = max64(c.PartSize, 1)
-	g.c.NTry = max(c.NTry, 1)
-	g.c.Concurrency = max(c.Concurrency, 1)
 
-	g.getCh = make(chan *Chunk, c.Concurrency)
-	g.readCh = make(chan *Chunk, c.Concurrency)
-	g.quit = make(chan struct{})
-	g.qWait = make(map[int]*Chunk)
-	g.b = b
-	g.md5 = md5.New()
-
-	//find out the total size of the requested file
-	resp, err := g.retryRequest("GET", getURL.String(), nil)
+	g, err := newBatchGetter(c, b)
 	if err != nil {
-		return nil, nil, err
-	}
-	if resp.StatusCode != 200 {
-		return nil, nil, newRespError(resp)
+		return g, nil, err
 	}
 
-	// Golang changes content-length to -1 when chunked transfer encoding / EOF close response detected
-	if resp.ContentLength == -1 {
-		return nil, nil, fmt.Errorf("Retrieving objects with undefined content-length " +
-			" responses (chunked transfer encoding / EOF close) is not supported")
-	}
+	header, err := g.queueFile(&getURL)
 
-	g.contentLen = resp.ContentLength
-	g.chunkTotal = int((g.contentLen + g.bufsz - 1) / g.bufsz) // round up, integer division
-	logger.debugPrintf("object size: %3.2g MB", float64(g.contentLen)/float64((1*mb)))
+	go func(){
+		g.chunkWg.Wait()
+		close(g.getCh)
+		g.wg.Wait()
+		close(g.readCh)
+	}()
 
-	g.sp = bufferPool(g.bufsz)
-
-	for i := 0; i < g.c.Concurrency; i++ {
-		go g.worker()
-	}
-	go g.initChunks(resp)
-	return g, resp.Header, nil
+	return g, header, err
 }
 
 func (g *getter) retryRequest(method, urlStr string, body io.ReadSeeker) (resp *http.Response, err error) {
@@ -161,105 +128,77 @@ func (g *getter) retryRequest(method, urlStr string, body io.ReadSeeker) (resp *
 	return
 }
 
-func (bg *batchGetter) queueFile(url *url.URL) error {
+func (g *getter) queueFile(url *url.URL) (http.Header, error) {
 
-	resp, err := bg.retryRequest("GET", url.String(), nil)
+	g.chunkWg.Add(1)
+	resp, err := g.retryRequest("GET", url.String(), nil)
 	if err != nil {
-		return err
+		return resp.Header, err
 	}
 
 	if resp.StatusCode != 200 {
-		return fmt.Errorf("Bad status for HTTP response: %d", resp.StatusCode)
+		return resp.Header, fmt.Errorf("Bad status for HTTP response: %d", resp.StatusCode)
 	}
 
 	// Golang changes content-length to -1 when chunked transfer encoding / EOF close response detected
 	if resp.ContentLength == -1 {
-		return fmt.Errorf("Retrieving objects with undefined content-length " +
+		return resp.Header, fmt.Errorf("Retrieving objects with undefined content-length " +
 			" responses (chunked transfer encoding / EOF close) is not supported")
 	}
 
-	bg.contentLen += resp.ContentLength
-	bg.chunkTotal += int((resp.ContentLength + bg.bufsz - 1) / bg.bufsz) // round up, integer division
+	g.contentLen += resp.ContentLength
+	g.chunkTotal += int((resp.ContentLength + g.bufsz - 1) / g.bufsz) // round up, integer division
 
 	logger.debugPrintf("object size: %3.2g MB", float64(resp.ContentLength)/float64((1*mb)))
-	go bg.initChunks(resp, url.String())
-	return nil
+	go g.initChunks(resp, url.String())
+	return resp.Header, nil
 }
 
-func (bg *batchGetter) initChunks(resp *http.Response, path string) {
+func (g *getter) initChunks(resp *http.Response, path string) {
 	for i := int64(0); i < resp.ContentLength; {
-		size := min64(bg.bufsz, resp.ContentLength-i)
-		c := &Chunk{
-			Id: bg.chunkCounter,
-			header: http.Header{
-				"Range": {fmt.Sprintf("bytes=%d-%d",
-					i, i+size-1)},
-			},
-			Start:     i,
-			ChunkSize: size,
-			Bytes:     nil,
-			url:       *resp.Request.URL,
-			Path:      path,
-			FileSize:  resp.ContentLength,
-		}
-
-		//Re-use the response for the first chunk
-		if i == 0 {
-			c.response = resp
-		}
-		i += size
-		bg.chunkCounter++
-		bg.wg.Add(1)
-		bg.getCh <- c
-	}
-	bg.chunkWg.Done()
-}
-
-
-func (g *singleGetter) initChunks(resp *http.Response) {
-	id := 0
-	for i := int64(0); i < g.contentLen; {
 		for len(g.qWait) >= qWaitSz {
 			// Limit growth of qWait
 			time.Sleep(100 * time.Millisecond)
 		}
-		size := min64(g.bufsz, g.contentLen-i)
-		c := &Chunk{
-			Id: id,
+		size := min64(g.bufsz, resp.ContentLength-i)
+		c := &chunk{
+			id: g.chunkCounter,
 			header: http.Header{
 				"Range": {fmt.Sprintf("bytes=%d-%d",
 					i, i+size-1)},
 			},
-			Start: i,
-			ChunkSize:  size,
-			Bytes:     nil,
-			url:   *resp.Request.URL,
+			start:     i,
+			size:	   size,
+			b:         nil,
+			url:       *resp.Request.URL,
+			path:      path,
+			fileSize:  resp.ContentLength,
 		}
 
 		//Re-use the response for the first chunk
 		if i == 0 {
 			c.response = resp
 		}
-
 		i += size
-		id++
+		g.chunkCounter++
 		g.wg.Add(1)
 		g.getCh <- c
 	}
-	close(g.getCh)
+	g.chunkWg.Done()
 }
 
 func (g *getter) worker() {
 	for c := range g.getCh {
 		g.retryGetChunk(c)
 	}
+
 }
 
-func (g *getter) retryGetChunk(c *Chunk) {
+func (g *getter) retryGetChunk(c *chunk) {
 	defer g.wg.Done()
 	var err error
 
-	c.Bytes = <-g.sp.get
+	c.b = <-g.sp.get
 
 	for i := 0; i < g.c.NTry; i++ {
 		time.Sleep(time.Duration(math.Exp2(float64(i))) * 100 * time.Millisecond) // exponential back-off
@@ -267,17 +206,17 @@ func (g *getter) retryGetChunk(c *Chunk) {
 		if err == nil {
 			return
 		}
-		logger.debugPrintf("error on attempt %d: retrying chunk: %v, error: %s", i, c.Id, err)
+		logger.debugPrintf("error on attempt %d: retrying chunk: %v, error: %s", i, c.id, err)
 		//If there is a re-used response in this chunk, it should be discarded since an error was returned
 		c.response = nil
 	}
 	g.err = err
-	c.Error = err
+	c.error = err
 	g.readCh <- c //expose error to the chunk handler
 	close(g.quit) // out of tries, ensure quit by closing channel
 }
 
-func (g *getter) getChunk(c *Chunk) error {
+func (g *getter) getChunk(c *chunk) error {
 	var resp *http.Response
 
 	//The first chunk will have the initial response in it to re-use
@@ -304,13 +243,13 @@ func (g *getter) getChunk(c *Chunk) error {
 	var err error
 	defer checkClose(resp.Body, &err)
 
-	n, err := io.ReadAtLeast(resp.Body, c.Bytes, int(c.ChunkSize))
+	n, err := io.ReadAtLeast(resp.Body, c.b, int(c.size))
 	if err != nil {
 		return err
 	}
-	if int64(n) != c.ChunkSize {
+	if int64(n) != c.size {
 		return fmt.Errorf("chunk %d: Expected %d bytes, received %d",
-		c.Id, c.ChunkSize, n)
+				c.id, c.size, n)
 	}
 	g.readCh <- c
 	return nil
@@ -349,13 +288,13 @@ func (g *getter) Read(p []byte) (int, error) {
 			g.cIdx = 0
 		}
 
-		n := copy(p[nw:], g.rChunk.Bytes[g.cIdx:g.rChunk.ChunkSize])
+		n := copy(p[nw:], g.rChunk.b[g.cIdx:g.rChunk.size])
 		g.cIdx += int64(n)
 		nw += n
 		g.bytesRead += int64(n)
 
-		if g.cIdx >= g.rChunk.ChunkSize { // chunk complete
-			g.sp.give <- g.rChunk.Bytes
+		if g.cIdx >= g.rChunk.size { // chunk complete
+			g.sp.give <- g.rChunk.b
 			g.chunkID++
 			g.rChunk = nil
 		}
@@ -364,22 +303,22 @@ func (g *getter) Read(p []byte) (int, error) {
 
 }
 
-func (g *batchGetter) WriteToWriterAt(w io.WriterAt) (int, error){
+func (g *getter) WriteToWriterAt(w io.WriterAt) (int, error){
 	fileOffsetMap := make(map[string]int64)
 	filePosition := int64(0)
 	totalWritten := int(0)
 
 	for chunk := range g.readCh {
-		fileOffset, present := fileOffsetMap[chunk.Path]
+		fileOffset, present := fileOffsetMap[chunk.path]
 		if !present {
 			fileOffset = filePosition
-			fileOffsetMap[chunk.Path] = filePosition
-			filePosition += chunk.FileSize
+			fileOffsetMap[chunk.path] = filePosition
+			filePosition += chunk.fileSize
 		}
 
 		var chunkWritten int = 0
-		for (int64(chunkWritten) < chunk.ChunkSize){
-			n, err := w.WriteAt(chunk.Bytes[:chunk.ChunkSize], fileOffset + chunk.Start)
+		for (int64(chunkWritten) < chunk.size){
+			n, err := w.WriteAt(chunk.b[:chunk.size], fileOffset + chunk.start)
 			chunkWritten += n
 			totalWritten += n
 			if err != nil {
@@ -387,12 +326,12 @@ func (g *batchGetter) WriteToWriterAt(w io.WriterAt) (int, error){
 			}
 		}
 
-		g.sp.give <- chunk.Bytes
+		g.sp.give <- chunk.b
 	}
 	return totalWritten, nil
 }
 
-func (g *batchGetter) WriteTo(w io.Writer) (int64, error) {
+func (g *getter) WriteTo(w io.Writer) (int64, error) {
 	// use WriteAt if present so chunks can be written out of order and release memory faster
 	if wa, ok := w.(io.WriterAt); ok {
 		nw, err := g.WriteToWriterAt(wa)
@@ -432,7 +371,7 @@ func (g *batchGetter) WriteTo(w io.Writer) (int64, error) {
 			g.cIdx = 0
 		}
 
-		n, writeError := w.Write(g.rChunk.Bytes[g.cIdx:g.rChunk.ChunkSize])
+		n, writeError := w.Write(g.rChunk.b[g.cIdx:g.rChunk.size])
 		g.cIdx += int64(n)
 		nw += int64(n)
 		g.bytesRead += int64(n)
@@ -441,8 +380,8 @@ func (g *batchGetter) WriteTo(w io.Writer) (int64, error) {
 			return nw, err
 		}
 
-		if g.cIdx >= g.rChunk.ChunkSize { // chunk complete
-			g.sp.give <- g.rChunk.Bytes
+		if g.cIdx >= g.rChunk.size { // chunk complete
+			g.sp.give <- g.rChunk.b
 			g.chunkID++
 			g.rChunk = nil
 		}
@@ -451,7 +390,7 @@ func (g *batchGetter) WriteTo(w io.Writer) (int64, error) {
 
 }
 
-func (g *getter) nextChunk() (*Chunk, error) {
+func (g *getter) nextChunk() (*chunk, error) {
 	for {
 
 		// first check qWait
@@ -459,7 +398,7 @@ func (g *getter) nextChunk() (*Chunk, error) {
 		if c != nil {
 			delete(g.qWait, g.chunkID)
 			if g.c.Md5Check {
-				if _, err := g.md5.Write(c.Bytes[:c.ChunkSize]); err != nil {
+				if _, err := g.md5.Write(c.b[:c.size]); err != nil {
 					return nil, err
 				}
 			}
@@ -468,7 +407,7 @@ func (g *getter) nextChunk() (*Chunk, error) {
 		// if next chunk not in qWait, read from channel
 		select {
 		case c := <-g.readCh:
-			g.qWait[c.Id] = c
+			g.qWait[c.id] = c
 		case <-g.quit:
 			return nil, g.err // fatal error, quit.
 		}

--- a/s3gof3r.go
+++ b/s3gof3r.go
@@ -82,21 +82,20 @@ func (s3 *S3) Bucket(name string) *Bucket {
 //workers defined in Config. This method returns a channel to receive chunks as they are completed. Chunks can
 //(and likely will) be returned out of order.
 // DefaultConfig is used if c is nil
-func (b *Bucket) GetMultiple(c *Config, files []string) (*batchGetter, error) {
+func (b *Bucket) GetMultiple(c *Config, files []string) (*getter, error) {
 
 	if c == nil {
 		c = b.conf()
 	}
 
-	batchGetter := newBatchGetter(c, b)
+	batchGetter, err := newBatchGetter(c, b)
 
 	for _, file := range files {
 		u, err := b.url(file, c)
 		if err != nil {
 			return nil, err
 		}
-		batchGetter.chunkWg.Add(1)
-		err = batchGetter.queueFile(u)
+		_, err = batchGetter.queueFile(u)
 		if err != nil {
 			return nil, err
 		}
@@ -109,7 +108,7 @@ func (b *Bucket) GetMultiple(c *Config, files []string) (*batchGetter, error) {
 		close(batchGetter.readCh)
 	}()
 
-	return batchGetter, nil
+	return batchGetter, err
 }
 
 // GetReader provides a reader and downloads data using parallel ranged get requests.


### PR DESCRIPTION
-Combine singleGetter/batchGetter into single getter struct
-Implement WriterTo interface to be used with io.Copy
-WriterTo also supports using WriteAt for out-of-order writes, if the Writer implements that method
