### PR TITLE
Bugfix/tunebi 64 duplicate loads

### DIFF
--- a/getter.go
+++ b/getter.go
@@ -28,6 +28,7 @@ type getter struct {
 	wg    sync.WaitGroup
 
 	chunkID      int64
+	fileCounter  int64
 	rChunk       *chunk
 	contentLen   int64
 	bytesRead    int64
@@ -60,6 +61,7 @@ type chunk struct {
 	header   http.Header
 	response *http.Response
 	url      url.URL
+	fileNum  int64  // The file number, reflecting the call to initChunks() that created this instance
 }
 
 func newBatchGetter(c *Config, b *Bucket) (*getter, error) {
@@ -77,6 +79,7 @@ func newBatchGetter(c *Config, b *Bucket) (*getter, error) {
 	g.md5 = md5.New()
 	g.chunkTotal = 0
 	g.chunkCounter = 0
+	g.fileCounter = 0
 
 	g.sp = bufferPool(g.bufsz)
 
@@ -185,6 +188,7 @@ func (g *getter) queueFile(url *url.URL) (http.Header, error) {
 }
 
 func (g *getter) initChunks(resp *http.Response, path string) {
+	fileNum := atomic.AddInt64(&g.fileCounter, 1)
 	for i := int64(0); i < resp.ContentLength; {
 		for len(g.qWait) >= qWaitSz {
 			// Limit growth of qWait
@@ -203,6 +207,7 @@ func (g *getter) initChunks(resp *http.Response, path string) {
 			url:      *resp.Request.URL,
 			path:     path,
 			fileSize: resp.ContentLength,
+			fileNum:  fileNum,
 		}
 
 		//Re-use the response for the first chunk
@@ -338,15 +343,15 @@ func (g *getter) Read(p []byte) (int, error) {
 }
 
 func (g *getter) WriteToWriterAt(w io.WriterAt) (int, error) {
-	fileOffsetMap := make(map[string]int64)
+	fileOffsetMap := make(map[int64]int64)
 	filePosition := int64(0)
 	totalWritten := int(0)
 
 	for chunk := range g.readCh {
-		fileOffset, present := fileOffsetMap[chunk.path]
+		fileOffset, present := fileOffsetMap[chunk.fileNum]
 		if !present {
 			fileOffset = filePosition
-			fileOffsetMap[chunk.path] = filePosition
+			fileOffsetMap[chunk.fileNum] = filePosition
 			filePosition += chunk.fileSize
 		}
 

--- a/getter.go
+++ b/getter.go
@@ -11,9 +11,9 @@ import (
 	"net/http"
 	"net/url"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
-	"sync/atomic"
 )
 
 const (
@@ -51,7 +51,7 @@ type getter struct {
 }
 
 type chunk struct {
-	id       int64    // The chunk number for the file being retrieved
+	id       int64  // The chunk number for the file being retrieved
 	start    int64  // The position in the requested file at which this chunk's data begins
 	size     int64  // Number of bytes contained in this chunk
 	fileSize int64  // Total size of the requested file
@@ -61,7 +61,7 @@ type chunk struct {
 	header   http.Header
 	response *http.Response
 	url      url.URL
-	fileNum  int64  // The file number, reflecting the call to initChunks() that created this instance
+	fileNum  int64 // The file number, reflecting the call to initChunks() that created this instance
 }
 
 func newBatchGetter(c *Config, b *Bucket) (*getter, error) {
@@ -177,7 +177,7 @@ func (g *getter) queueFile(url *url.URL) (http.Header, error) {
 	}
 
 	atomic.AddInt64(&g.contentLen, resp.ContentLength)
-	atomic.AddInt64(&g.chunkTotal, int64((resp.ContentLength + g.bufsz - 1) / g.bufsz))// round up, integer division
+	atomic.AddInt64(&g.chunkTotal, int64((resp.ContentLength+g.bufsz-1)/g.bufsz)) // round up, integer division
 
 	logger.debugPrintf("object size: %3.2g MB", float64(resp.ContentLength)/float64((1*mb)))
 	go func() {

--- a/s3gof3r.go
+++ b/s3gof3r.go
@@ -13,8 +13,8 @@ import (
 	"net/url"
 	"path"
 	"strings"
-	"time"
 	"sync"
+	"time"
 )
 
 // S3 contains the domain or endpoint of an S3-compatible service and
@@ -99,7 +99,7 @@ func (b *Bucket) GetMultiple(c *Config, files []string) (*getter, error) {
 	}
 	var errorSlice []error
 
-	for i:=0; i < c.Concurrency; i++{
+	for i := 0; i < c.Concurrency; i++ {
 		wg.Add(1)
 		go func() {
 			for file := range fileCh {
@@ -126,15 +126,13 @@ func (b *Bucket) GetMultiple(c *Config, files []string) (*getter, error) {
 		close(fileCh)
 	}()
 
-
-	go func () {
+	go func() {
 		for err := range errCh {
 			errorSlice = append(errorSlice, err)
 		}
 	}()
 	wg.Wait()
 	close(errCh)
-
 
 	if len(errorSlice) > 0 {
 		errStr := "Error(s) found while retrieving files\n"

--- a/s3gof3r_test.go
+++ b/s3gof3r_test.go
@@ -1,6 +1,5 @@
 package s3gof3r
 
-
 import (
 	"bytes"
 	"crypto/rand"
@@ -493,41 +492,41 @@ but the duplicated files were only loaded once.  One bug masking another.  This 
 that GetMultiple isn't responsible for that.  It relies on files currently in the 'tunedb-tetris-beta' S3
 bucket.  To run it you'll need to set your tunedb AWS creds in the usual env vars.  */
 func TestGetMultiple(t *testing.T) {
-	
+
 	keys, err := EnvKeys()
 	if err != nil {
 		t.Fatal(err)
 		return
 	}
 	s3 := New("", keys)
-	
+
 	var s3gof3rConfig = DefaultConfig
 	s3gof3rConfig.Md5Check = false
 	s3gof3rConfig.Scheme = "http"
 	s3gof3rConfig.Concurrency = 10
 	s3gof3rConfig.NTry = 5
 	s3gof3rConfig.Client = ClientWithTimeout(5 * time.Second)
-	
+
 	s3Bucket := s3.Bucket("tunedb-tetris-beta")
-	
+
 	prefix := "/log/retl/7336/log_conversions/1_2/2015/11/"
 	importS3Files := []string{
-		prefix + "7336-log_conversions-1_2-20151101-8bd224456aa74852bb50f26a6028dd79.csv",   // a 5KB file
-		prefix + "7336-log_conversions-1_2-20151101-176ae58c9476428592094508a0281c3b.csv",   // a 16KB file
-		prefix + "7336-log_conversions-1_2-20151101-8bd224456aa74852bb50f26a6028dd79.csv",   // dup of the 5KB file
+		prefix + "7336-log_conversions-1_2-20151101-8bd224456aa74852bb50f26a6028dd79.csv", // a 5KB file
+		prefix + "7336-log_conversions-1_2-20151101-176ae58c9476428592094508a0281c3b.csv", // a 16KB file
+		prefix + "7336-log_conversions-1_2-20151101-8bd224456aa74852bb50f26a6028dd79.csv", // dup of the 5KB file
 	}
-	
+
 	// a log_id from the 5KB file
 	logID := "a9c8d17bf8c51aaa82-20151101-7336"
 
 	getter, err := s3Bucket.GetMultiple(s3gof3rConfig, importS3Files)
-	
+
 	if err != nil {
 		t.Fatal("got an error calling GetMultiple():", err)
 		return
 	}
 	defer getter.Close()
-	
+
 	buffer := make([]byte, 30000)
 	_, err = getter.Read(buffer)
 	if err != nil && err != io.EOF {
@@ -542,5 +541,5 @@ func TestGetMultiple(t *testing.T) {
 		t.Fail()
 		return
 	}
-	
+
 }

--- a/s3gof3r_test.go
+++ b/s3gof3r_test.go
@@ -1,5 +1,6 @@
 package s3gof3r
 
+
 import (
 	"bytes"
 	"crypto/rand"
@@ -196,7 +197,6 @@ func testBucket() (*tB, error) {
 	bucket := os.Getenv("TEST_BUCKET")
 	if bucket == "" {
 		return nil, errors.New("TEST_BUCKET must be set in environment")
-
 	}
 	s3 := New("", k)
 	b := tB{s3.Bucket(bucket)}
@@ -486,5 +486,61 @@ func TestGetterAfterError(t *testing.T) {
 	if err != terr {
 		t.Errorf("expected error %v on Close, got %v", terr, err)
 	}
+}
 
+/* Troubleshooting TUNEBI-64, we noticed multiple files being listed in a single SQS message,
+but the duplicated files were only loaded once.  One bug masking another.  This test verifies
+that GetMultiple isn't responsible for that.  It relies on files currently in the 'tunedb-tetris-beta' S3
+bucket.  To run it you'll need to set your tunedb AWS creds in the usual env vars.  */
+func TestGetMultiple(t *testing.T) {
+	
+	keys, err := EnvKeys()
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+	s3 := New("", keys)
+	
+	var s3gof3rConfig = DefaultConfig
+	s3gof3rConfig.Md5Check = false
+	s3gof3rConfig.Scheme = "http"
+	s3gof3rConfig.Concurrency = 10
+	s3gof3rConfig.NTry = 5
+	s3gof3rConfig.Client = ClientWithTimeout(5 * time.Second)
+	
+	s3Bucket := s3.Bucket("tunedb-tetris-beta")
+	
+	prefix := "/log/retl/7336/log_conversions/1_2/2015/11/"
+	importS3Files := []string{
+		prefix + "7336-log_conversions-1_2-20151101-8bd224456aa74852bb50f26a6028dd79.csv",   // a 5KB file
+		prefix + "7336-log_conversions-1_2-20151101-176ae58c9476428592094508a0281c3b.csv",   // a 16KB file
+		prefix + "7336-log_conversions-1_2-20151101-8bd224456aa74852bb50f26a6028dd79.csv",   // dup of the 5KB file
+	}
+	
+	// a log_id from the 5KB file
+	logID := "a9c8d17bf8c51aaa82-20151101-7336"
+
+	getter, err := s3Bucket.GetMultiple(s3gof3rConfig, importS3Files)
+	
+	if err != nil {
+		t.Fatal("got an error calling GetMultiple():", err)
+		return
+	}
+	defer getter.Close()
+	
+	buffer := make([]byte, 30000)
+	_, err = getter.Read(buffer)
+	if err != nil && err != io.EOF {
+		t.Fatal("unexpected error copying getter -> buffer:", err)
+		return
+	}
+
+	// make sure there are 2 instance of the log_id above
+	logIDCount := strings.Count(string(buffer), logID)
+	if logIDCount != 2 {
+		t.Errorf("Error counting instances of log_id, expected 2 got %d", logIDCount)
+		t.Fail()
+		return
+	}
+	
 }


### PR DESCRIPTION
dbimport.concat() exposed this problem.  Files listed twice in a single call to GetMultiple(), where the data was pulled out through the WriteToWriterAt interface, would only be returned once.  The data would be fetched from S3 twice but mapped to the same offset in the output.  Added a fileNum param to disambiguate.
