### PR TITLE
Bugfix/tunebi 64 duplicate loads

### DIFF
--- a/getter.go
+++ b/getter.go
@@ -28,6 +28,7 @@ type getter struct {
 	wg    sync.WaitGroup
 
 	chunkID      int64
+	fileCounter  int64
 	rChunk       *chunk
 	contentLen   int64
 	bytesRead    int64
@@ -60,6 +61,7 @@ type chunk struct {
 	header   http.Header
 	response *http.Response
 	url      url.URL
+	fileNum  int64  // The file number, reflecting the call to initChunks() that created this instance
 }
 
 func newBatchGetter(c *Config, b *Bucket) (*getter, error) {
@@ -77,6 +79,7 @@ func newBatchGetter(c *Config, b *Bucket) (*getter, error) {
 	g.md5 = md5.New()
 	g.chunkTotal = 0
 	g.chunkCounter = 0
+	g.fileCounter = 0
 
 	g.sp = bufferPool(g.bufsz)
 
@@ -185,6 +188,7 @@ func (g *getter) queueFile(url *url.URL) (http.Header, error) {
 }
 
 func (g *getter) initChunks(resp *http.Response, path string) {
+	fileNum := atomic.AddInt64(&g.fileCounter, 1)
 	for i := int64(0); i < resp.ContentLength; {
 		for len(g.qWait) >= qWaitSz {
 			// Limit growth of qWait
@@ -203,6 +207,7 @@ func (g *getter) initChunks(resp *http.Response, path string) {
 			url:      *resp.Request.URL,
 			path:     path,
 			fileSize: resp.ContentLength,
+			fileNum:  fileNum,
 		}
 
 		//Re-use the response for the first chunk
@@ -338,15 +343,15 @@ func (g *getter) Read(p []byte) (int, error) {
 }
 
 func (g *getter) WriteToWriterAt(w io.WriterAt) (int, error) {
-	fileOffsetMap := make(map[string]int64)
+	fileOffsetMap := make(map[int64]int64)
 	filePosition := int64(0)
 	totalWritten := int(0)
 
 	for chunk := range g.readCh {
-		fileOffset, present := fileOffsetMap[chunk.path]
+		fileOffset, present := fileOffsetMap[chunk.fileNum]
 		if !present {
 			fileOffset = filePosition
-			fileOffsetMap[chunk.path] = filePosition
+			fileOffsetMap[chunk.fileNum] = filePosition
 			filePosition += chunk.fileSize
 		}
 

--- a/getter.go
+++ b/getter.go
@@ -11,9 +11,9 @@ import (
 	"net/http"
 	"net/url"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
-	"sync/atomic"
 )
 
 const (
@@ -51,7 +51,7 @@ type getter struct {
 }
 
 type chunk struct {
-	id       int64    // The chunk number for the file being retrieved
+	id       int64  // The chunk number for the file being retrieved
 	start    int64  // The position in the requested file at which this chunk's data begins
 	size     int64  // Number of bytes contained in this chunk
 	fileSize int64  // Total size of the requested file
@@ -61,7 +61,7 @@ type chunk struct {
 	header   http.Header
 	response *http.Response
 	url      url.URL
-	fileNum  int64  // The file number, reflecting the call to initChunks() that created this instance
+	fileNum  int64 // The file number, reflecting the call to initChunks() that created this instance
 }
 
 func newBatchGetter(c *Config, b *Bucket) (*getter, error) {
@@ -177,7 +177,7 @@ func (g *getter) queueFile(url *url.URL) (http.Header, error) {
 	}
 
 	atomic.AddInt64(&g.contentLen, resp.ContentLength)
-	atomic.AddInt64(&g.chunkTotal, int64((resp.ContentLength + g.bufsz - 1) / g.bufsz))// round up, integer division
+	atomic.AddInt64(&g.chunkTotal, int64((resp.ContentLength+g.bufsz-1)/g.bufsz)) // round up, integer division
 
 	logger.debugPrintf("object size: %3.2g MB", float64(resp.ContentLength)/float64((1*mb)))
 	go func() {

--- a/s3gof3r.go
+++ b/s3gof3r.go
@@ -13,8 +13,8 @@ import (
 	"net/url"
 	"path"
 	"strings"
-	"time"
 	"sync"
+	"time"
 )
 
 // S3 contains the domain or endpoint of an S3-compatible service and
@@ -99,7 +99,7 @@ func (b *Bucket) GetMultiple(c *Config, files []string) (*getter, error) {
 	}
 	var errorSlice []error
 
-	for i:=0; i < c.Concurrency; i++{
+	for i := 0; i < c.Concurrency; i++ {
 		wg.Add(1)
 		go func() {
 			for file := range fileCh {
@@ -126,15 +126,13 @@ func (b *Bucket) GetMultiple(c *Config, files []string) (*getter, error) {
 		close(fileCh)
 	}()
 
-
-	go func () {
+	go func() {
 		for err := range errCh {
 			errorSlice = append(errorSlice, err)
 		}
 	}()
 	wg.Wait()
 	close(errCh)
-
 
 	if len(errorSlice) > 0 {
 		errStr := "Error(s) found while retrieving files\n"

--- a/s3gof3r_test.go
+++ b/s3gof3r_test.go
@@ -196,7 +196,6 @@ func testBucket() (*tB, error) {
 	bucket := os.Getenv("TEST_BUCKET")
 	if bucket == "" {
 		return nil, errors.New("TEST_BUCKET must be set in environment")
-
 	}
 	s3 := New("", k)
 	b := tB{s3.Bucket(bucket)}


### PR DESCRIPTION
When a file was requested multiple times through GetMultiple(), and then pulled out through the WriteToWriterAt() interface, only one copy of the file would come out.  The offset map was keyed on filename, so those duplicate requests would clobber each other at the same position in the output.  Fixed it.
